### PR TITLE
Added placeholder to fix warning for Droppable setup issue

### DIFF
--- a/src/components/TaskWindow.tsx
+++ b/src/components/TaskWindow.tsx
@@ -46,6 +46,7 @@ export const TaskWindow = () => {
                 ))}
               </div>
             </div>
+            {provided.placeholder}
           </Expand>
         )}
       </Droppable>
@@ -56,7 +57,7 @@ export const TaskWindow = () => {
 const Task = ({ task, index }: { task: Task; index: number }) => {
   const isAgentStopped = useAgentStore.use.isAgentStopped();
   return (
-    <Draggable draggableId={task.taskId} index={index}>
+    <Draggable draggableId={task.taskId!} index={index}>
       {(provided) => (
         <FadeIn>
           <div


### PR DESCRIPTION
Before: 
<img width="601" alt="image" src="https://user-images.githubusercontent.com/31974570/235812224-8e695468-e9a2-4332-921a-6cc415d4e59d.png">

After:
no warning now
